### PR TITLE
Setting for preventing needless tugging when leashed.

### DIFF
--- a/device/oc_leash.lsl
+++ b/device/oc_leash.lsl
@@ -1,92 +1,57 @@
 /*------------------------------------------------------------------------------
-
  Leash, Build 137
-
  Wendy's OpenCollar Distribution
  https://github.com/wendystarfall/opencollar
-
 --------------------------------------------------------------------------------
-
  OpenCollar v1.000 - v3.600 (OpenCollar - submission set free):
-
  Copyright © 2008, 2009, 2010 Cleo Collins, Garvin Twine, Joy Stipe, Lulu Pink,
  Master Starship, Nandana Singh, Toy Wylie, et al.
-
  The project in its original form concluded on October 19, 2011. Everything past
  this date is a derivative of OpenCollar's original SVN trunk from Google Code.
-
 --------------------------------------------------------------------------------
-
  OpenCollar v3.700 - v3.720 (nirea's ocupdater):
-
  Copyright © 2011 Kaori Gray, nirea, Satomi Ahn, Sei Lisa
-
  https://github.com/OpenCollarUpdates/ocupdater/commits/release
-
 --------------------------------------------------------------------------------
-
  OpenCollar v3.750 - v3.809 (Satomi's OpenCollarUpdates):
-
  Copyright © 2012 Satomi Ahn
-
  https://github.com/OpenCollarUpdates/ocupdater/commits/3.8
  https://github.com/OpenCollarUpdates/ocupdater/commits/beta
-
 --------------------------------------------------------------------------------
-
  OpenCollar v3.809 - v3.843 (Joy's OpenCollar Evolution):
-
  Copyright © 2013 Joy Stipe
-
  https://github.com/JoyStipe/ocupdater/commits/Project_Evolution
-
 --------------------------------------------------------------------------------
-
  OpenCollar v3.844 - v3.998 (Wendy's OpenCollar API 3.9):
-
  Copyright © 2013 Karo Weirsider, Wendy Starfall
  Copyright © 2014 littlemousy, Marissa Mistwallow, Romka Swallowtail, Sumi Perl,
  Wendy Starfall
  Copyright © 2015 Kurt Burleigh, Wendy Starfall
-
  https://github.com/OpenCollar/opencollar/commits/master
  https://github.com/WendyStarfall/opencollar/commits/master
-
 --------------------------------------------------------------------------------
-
  Virtual Disgrace Collar v1.0.0 - v2.1.1 (virtualdisgrace.com):
-
  Copyright © 2011, 2012, 2013 Wendy Starfall
  Copyright © 2014 littlemousy, Wendy Starfall
-
  https://github.com/WendyStarfall/opencollar/commits/master
  https://github.com/VirtualDisgrace/opencollar/commits/master
-
 --------------------------------------------------------------------------------
-
  OpenCollar v4.0.0 - v6.7.5 - Peanut build 9 (virtualdisgrace.com):
-
  Copyright © 2015, 2016 Garvin Twine, Romka Swallowtail, Wendy Starfall
  Copyright © 2018 Garvin Twine, klixi, Wendy Starfall
-
  https://github.com/VirtualDisgrace/opencollar/commits/master
  https://github.com/WendyStarfall/opencollar/commits/master
-
 --------------------------------------------------------------------------------
-
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  as published by the Free Software Foundation; either version 2
  of the License, or (at your option) any later version.
-
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
-
  You should have received a copy of the GNU General Public License
  along with this program; if not, see www.gnu.org/licenses/gpl-2.0
-
 ------------------------------------------------------------------------------*/
 
 integer g_iBuild = 137;
@@ -160,6 +125,7 @@ string g_sCheck;
 
 integer g_iStrictModeOn;
 integer g_iTurnModeOn;
+integer g_iNoTug;
 integer g_iLeasherInRange;
 integer g_iRLVOn;
 integer g_iAwayCounter;
@@ -331,7 +297,7 @@ DoLeash(key kTarget, integer iAuth, list lPoints) {
     llTargetRemove(g_iTargetHandle);
     llStopMoveToTarget();
     g_iTargetHandle = llTarget(g_vPos, (float)g_iLength);
-    if (g_vPos != ZERO_VECTOR) {
+    if (g_vPos != ZERO_VECTOR && !g_iNoTug) {
         llMoveToTarget(g_vPos, 0.7);
     }
     llMessageLinked(LINK_SAVE, LM_SETTING_SAVE, g_sSettingToken + TOK_DEST + "=" + (string)kTarget + "," + (string)iAuth + "," + (string)g_bLeashedToAvi + "," + (string)g_bFollowMode, "");
@@ -647,12 +613,13 @@ default {
                     if (!llGetObjectPrimCount(kTarget) && !g_bLeashedToAvi) DoUnleash(TRUE);
                     else DoLeash(kTarget, (integer)llList2String(lParam, 1), lPoints);
                 } else if (sToken == TOK_LENGTH) SetLength((integer)sValue);
-                else if (sToken=="strict"){
+                else if (sToken == "strict"){
                     list lParam = llParseString2List(llGetSubString(sMessage, iInd + 1, -1), [","], []);
                     g_iStrictModeOn = (integer)sValue;
                     g_iStrictRank = (integer)llList2String(lParam, 1);
                     ApplyRestrictions();
                 } else if (sToken == "turn") g_iTurnModeOn = (integer)sValue;
+                else if (sToken == "notug") g_iNoTug = (integer)sValue;
             }
         } else if (iNum == RLV_ON) {
             g_iRLVOn = TRUE;

--- a/device/oc_leash.lsl
+++ b/device/oc_leash.lsl
@@ -1,57 +1,92 @@
 /*------------------------------------------------------------------------------
+
  Leash, Build 137
+
  Wendy's OpenCollar Distribution
  https://github.com/wendystarfall/opencollar
+
 --------------------------------------------------------------------------------
+
  OpenCollar v1.000 - v3.600 (OpenCollar - submission set free):
+
  Copyright © 2008, 2009, 2010 Cleo Collins, Garvin Twine, Joy Stipe, Lulu Pink,
  Master Starship, Nandana Singh, Toy Wylie, et al.
+
  The project in its original form concluded on October 19, 2011. Everything past
  this date is a derivative of OpenCollar's original SVN trunk from Google Code.
+
 --------------------------------------------------------------------------------
+
  OpenCollar v3.700 - v3.720 (nirea's ocupdater):
+
  Copyright © 2011 Kaori Gray, nirea, Satomi Ahn, Sei Lisa
+
  https://github.com/OpenCollarUpdates/ocupdater/commits/release
+
 --------------------------------------------------------------------------------
+
  OpenCollar v3.750 - v3.809 (Satomi's OpenCollarUpdates):
+
  Copyright © 2012 Satomi Ahn
+
  https://github.com/OpenCollarUpdates/ocupdater/commits/3.8
  https://github.com/OpenCollarUpdates/ocupdater/commits/beta
+
 --------------------------------------------------------------------------------
+
  OpenCollar v3.809 - v3.843 (Joy's OpenCollar Evolution):
+
  Copyright © 2013 Joy Stipe
+
  https://github.com/JoyStipe/ocupdater/commits/Project_Evolution
+
 --------------------------------------------------------------------------------
+
  OpenCollar v3.844 - v3.998 (Wendy's OpenCollar API 3.9):
+
  Copyright © 2013 Karo Weirsider, Wendy Starfall
  Copyright © 2014 littlemousy, Marissa Mistwallow, Romka Swallowtail, Sumi Perl,
  Wendy Starfall
  Copyright © 2015 Kurt Burleigh, Wendy Starfall
+
  https://github.com/OpenCollar/opencollar/commits/master
  https://github.com/WendyStarfall/opencollar/commits/master
+
 --------------------------------------------------------------------------------
+
  Virtual Disgrace Collar v1.0.0 - v2.1.1 (virtualdisgrace.com):
+
  Copyright © 2011, 2012, 2013 Wendy Starfall
  Copyright © 2014 littlemousy, Wendy Starfall
+
  https://github.com/WendyStarfall/opencollar/commits/master
  https://github.com/VirtualDisgrace/opencollar/commits/master
+
 --------------------------------------------------------------------------------
+
  OpenCollar v4.0.0 - v6.7.5 - Peanut build 9 (virtualdisgrace.com):
+
  Copyright © 2015, 2016 Garvin Twine, Romka Swallowtail, Wendy Starfall
  Copyright © 2018 Garvin Twine, klixi, Wendy Starfall
+
  https://github.com/VirtualDisgrace/opencollar/commits/master
  https://github.com/WendyStarfall/opencollar/commits/master
+
 --------------------------------------------------------------------------------
+
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
  as published by the Free Software Foundation; either version 2
  of the License, or (at your option) any later version.
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
+
  You should have received a copy of the GNU General Public License
  along with this program; if not, see www.gnu.org/licenses/gpl-2.0
+
 ------------------------------------------------------------------------------*/
 
 integer g_iBuild = 137;

--- a/settings/README.md
+++ b/settings/README.md
@@ -12,3 +12,6 @@ Settings that can be loaded directly from this directory into collars! Just copy
 
 * ``highlander~0`` disables the safety to prevent wearing multiple cores.
 ``https://raw.githubusercontent.com/WendyStarfall/opencollar/master/settings/highlander``
+
+* ``notug~1`` disables the slight tug that happens when first leashing a sub.
+``https://raw.githubusercontent.com/WendyStarfall/opencollar/master/settings/noleashtug``

--- a/settings/noleashtug
+++ b/settings/noleashtug
@@ -1,0 +1,1 @@
+LEASH=notug~1


### PR DESCRIPTION
Personally I think this entire check and llMoveToTarget call should get removed completely. If you're already in range then this nudge is useless resources spent on physics and if you're not in range the events should be what does the movement rather than this early short circuit.

Trying to discuss this in the Fire Flower group today was not very successful, so my initial PR is to leave the behavior but have a setting to turn it off. I think rather I'd like to just provide a PR removing this check and llMoveToTarget entirely if the maintainers prefer. If not, this solution is hopefully welcome for those who find this behavior annoying to be able to change it with a web setting. A third option I'd be willing to do is checking the distance here, and if this early push is still desired without a setting, can at least see if the sub is already in leash length range or not to avoid the extra pushing, though I honestly don't see the point of that.

Justification for the change: Often subs will very carefully position themselves in range of where they will be posted or leashed before they are. Once they are, even if they position perfectly to be in range, they still get tugged anyway, and then have to re-adjust their position again, as they often get shoved too close to the post or owner. This change aims to solve that, where if they are already in range, they are not shoved and disrupted having to reposition themselves again after being leashed.
